### PR TITLE
Use failPlugin instead of failBuild when checking environment variables

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,8 @@
 const { runQaWolfTests } = require('./qawolf')
 
 module.exports = {
-  // Runs after Build commands are executed
-  onPostBuild: async ({ utils }) => {
-    return runQaWolfTests('onPostBuild', utils)
-  },
   // Runs on build success
   onSuccess: async ({ utils }) => {
-    return runQaWolfTests('onSuccess', utils)
+    return runQaWolfTests(utils)
   },
 }

--- a/test/qawolf.test.js
+++ b/test/qawolf.test.js
@@ -3,58 +3,33 @@ const qawolf = require('../src/qawolf')
 
 jest.mock('axios')
 
-const failBuild = jest.fn()
 const failPlugin = jest.fn()
 const show = jest.fn()
 
 const utils = {
-  build: { failBuild, failPlugin },
+  build: { failPlugin },
   status: { show },
 }
 
 describe('runQaWolfTests', () => {
   afterEach(() => jest.clearAllMocks())
 
-  it('handles QA Wolf tests passing onPostBuild', async () => {
+  it('handles QA Wolf tests passing onSuccess', async () => {
     axios.post.mockResolvedValueOnce({ data: { suite_ids: ['suiteId'] } })
     axios.get.mockResolvedValueOnce({
       data: { is_complete: true, status: 'pass' },
     })
 
-    await qawolf.runQaWolfTests('onPostBuild', utils)
+    await qawolf.runQaWolfTests(utils)
 
     const postArgs = axios.post.mock.calls[0]
-    expect(postArgs[0]).toBe('https://www.qawolf.com/api/netlify/suites')
-    expect(postArgs[1]).toMatchObject({ netlify_event: 'onPostBuild' })
-
-    const getArgs = axios.get.mock.calls[0]
-    expect(getArgs[0]).toBe('https://www.qawolf.com/api/suites/suiteId')
+    expect(postArgs[2]).toMatchObject({
+      headers: { authorization: process.env.QAWOLF_API_KEY },
+    })
 
     expect(
-      failBuild.mock.calls[failBuild.mock.calls.length - 1][0],
-    ).not.toMatch('tests failed')
-
-    expect(show.mock.calls[0][0]).toEqual({
-      summary: 'tests passed',
-      text: 'https://www.qawolf.com/suites/suiteId',
-    })
-    expect(show.mock.calls[1][0]).toEqual({
-      summary: 'complete',
-      text: '🐺',
-    })
-  })
-
-  it('handles QA Wolf tests failing onPostBuild', async () => {
-    axios.post.mockResolvedValueOnce({ data: { suite_ids: ['suiteId'] } })
-    axios.get.mockResolvedValueOnce({
-      data: { is_complete: true, status: 'fail' },
-    })
-
-    await qawolf.runQaWolfTests('onPostBuild', utils)
-
-    expect(failBuild.mock.calls[failBuild.mock.calls.length - 1][0]).toMatch(
-      'tests failed, details at',
-    )
+      failPlugin.mock.calls[failPlugin.mock.calls.length - 1][0],
+    ).not.toMatch('qawolf: tests failed')
   })
 
   it('handles QA Wolf tests failing onSuccess', async () => {
@@ -63,20 +38,22 @@ describe('runQaWolfTests', () => {
       data: { is_complete: true, status: 'fail' },
     })
 
-    await qawolf.runQaWolfTests('onSuccess', utils)
+    await qawolf.runQaWolfTests(utils)
 
     const postArgs = axios.post.mock.calls[0]
-    expect(postArgs[1]).toMatchObject({ netlify_event: 'onSuccess' })
+    expect(postArgs[2]).toMatchObject({
+      headers: { authorization: process.env.QAWOLF_API_KEY },
+    })
 
-    expect(
-      failBuild.mock.calls[failBuild.mock.calls.length - 1][0],
-    ).not.toMatch('qawolf: tests failed')
+    expect(failPlugin.mock.calls[failPlugin.mock.calls.length - 1][0]).toMatch(
+      'tests failed, details at',
+    )
   })
 
   it('allows skipping the plugin', async () => {
     process.env.QAWOLF_SKIP = 'true'
 
-    await qawolf.runQaWolfTests('onSuccess', utils)
+    await qawolf.runQaWolfTests(utils)
 
     expect(show.mock.calls).toHaveLength(1)
     expect(show.mock.calls[0][0]).toEqual({


### PR DESCRIPTION
* resolves #9 
* also only runs the plugin `onSuccess` rather than also `onPostBuild`